### PR TITLE
Make Treatment Service max goroutines configurable and add profiling handler

### DIFF
--- a/treatment-service/config/config.go
+++ b/treatment-service/config/config.go
@@ -71,6 +71,7 @@ type SwaggerConfig struct {
 // DeploymentConfig captures the config related to the deployment of Treatment Service
 type DeploymentConfig struct {
 	EnvironmentType string `default:"local"`
+	MaxGoRoutines   int    `default:"100"`
 }
 
 type MetricSinkKind = string

--- a/treatment-service/config/config_test.go
+++ b/treatment-service/config/config_test.go
@@ -26,6 +26,7 @@ func TestDefaultConfigs(t *testing.T) {
 		},
 		DeploymentConfig: DeploymentConfig{
 			EnvironmentType: "local",
+			MaxGoRoutines:   100,
 		},
 		AssignedTreatmentLogger: AssignedTreatmentLoggerConfig{
 			Kind:                 "",
@@ -80,7 +81,7 @@ func TestLoadMultipleConfigs(t *testing.T) {
 			URL:                  "localhost:3000/v1",
 			AuthorizationEnabled: true,
 		},
-		DeploymentConfig: DeploymentConfig{EnvironmentType: "dev"},
+		DeploymentConfig: DeploymentConfig{EnvironmentType: "dev", MaxGoRoutines: 200},
 		AssignedTreatmentLogger: AssignedTreatmentLoggerConfig{
 			Kind:                 "bq",
 			QueueLength:          1073741824,

--- a/treatment-service/controller/internal.go
+++ b/treatment-service/controller/internal.go
@@ -18,7 +18,7 @@ type InternalController struct {
 
 func NewInternalController(ctx *appcontext.AppContext, cfg *config.Config) *InternalController {
 	healthCheckHandler := healthcheck.NewHandler()
-	healthCheckHandler.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(100))
+	healthCheckHandler.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(cfg.DeploymentConfig.MaxGoRoutines))
 
 	mux := http.NewServeMux()
 	mux.Handle("/health/", http.StripPrefix("/health", healthCheckHandler))

--- a/treatment-service/controller/internal.go
+++ b/treatment-service/controller/internal.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/heptiolabs/healthcheck"
 
@@ -21,7 +22,9 @@ func NewInternalController(ctx *appcontext.AppContext, cfg *config.Config) *Inte
 
 	mux := http.NewServeMux()
 	mux.Handle("/health/", http.StripPrefix("/health", healthCheckHandler))
-	mux.Handle("/debug", NewDebugHandler(ctx, cfg))
+	mux.Handle("/debug/dump", NewCacheDumpHandler(ctx, cfg))
+	// For profiling. net/http/pprof will register itself to http.DefaultServeMux.
+	mux.Handle("/debug/pprof/", http.DefaultServeMux)
 	return &InternalController{Handler: mux, AppContext: ctx, Config: cfg}
 }
 
@@ -30,7 +33,7 @@ type debugHandler struct {
 	Config *config.Config
 }
 
-func NewDebugHandler(ctx *appcontext.AppContext, cfg *config.Config) http.Handler {
+func NewCacheDumpHandler(ctx *appcontext.AppContext, cfg *config.Config) http.Handler {
 	return &debugHandler{AppContext: ctx, Config: cfg}
 }
 

--- a/treatment-service/testdata/config2.yaml
+++ b/treatment-service/testdata/config2.yaml
@@ -1,5 +1,6 @@
 DeploymentConfig:
   EnvironmentType: dev
+  MaxGoRoutines: 200
 
 SentryConfig:
   Enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: The Treatment service's liveness probe is currently set to check for a maximum of 100 goroutines exceeding which, the probe will fail. Internally, it has been observed that there are many more concurrently active goroutines than the previous releases. So, this PR does 2 things:
* Adds the default `net/http/pprof` profiling handler at the `/internal/debug/pprof/` endpoint, to get various [diagnostic data](https://go.dev/doc/diagnostics) on demand. It can be invoked as below:
```sh
go tool pprof -http=:8081 http://localhost:8080/v1/internal/debug/pprof/goroutine
```
* Makes the max goroutines value on the liveness probe configurable at deploy time.

With these changes, it should be possible to analyse the runtime performance of the treatment service better and determine if there are any goroutine leaks.
