### PR TITLE
Custom Segmenters: Miscellaneous UI Bugfixes

### DIFF
--- a/ui/src/experiments/components/form/CreateExperimentForm.js
+++ b/ui/src/experiments/components/form/CreateExperimentForm.js
@@ -11,7 +11,6 @@ import { GeneralStep } from "./steps/GeneralStep";
 import { SegmentStep } from "./steps/SegmentStep";
 import { TreatmentsStep } from "./steps/TreatmentsStep";
 import schema from "./validation/schema";
-import { parseSegmenterValue } from "services/experiment/Segment";
 
 export const CreateExperimentForm = ({ projectId, onCancel, onSuccess }) => {
   const validationSchema = useMemo(() => schema, []);
@@ -20,14 +19,14 @@ export const CreateExperimentForm = ({ projectId, onCancel, onSuccess }) => {
   const { segmenterConfig, getSegmenterOptions } = useContext(SegmenterContext);
 
   // retrieve name-type (in caps) mappings for active segmenters specified for this project
-  const segmenterTypes = getSegmenterOptions(segmenterConfig).reduce(function (
+  const segmenterTypes = getSegmenterOptions(segmenterConfig).reduce(function(
     map,
     obj
   ) {
     map[obj.name] = obj.type.toUpperCase();
     return map;
   },
-  {});
+    {});
 
   const requiredSegmenterNames = useMemo(
     () =>
@@ -46,16 +45,7 @@ export const CreateExperimentForm = ({ projectId, onCancel, onSuccess }) => {
     {},
     false
   );
-  const onSubmit = () => {
-    for (const key of Object.keys(experiment.segment)) {
-      experiment.segment[key] = experiment.segment[key].map(
-        (segmenterValue) => {
-          return parseSegmenterValue(segmenterValue, segmenterTypes[key]);
-        }
-      );
-    }
-    return submitForm({ body: experiment.stringify() }).promise;
-  };
+  const onSubmit = () => submitForm({ body: experiment.stringify() }).promise;
 
   useEffect(() => {
     if (submissionResponse.isLoaded && !submissionResponse.error) {

--- a/ui/src/experiments/components/form/CreateExperimentForm.js
+++ b/ui/src/experiments/components/form/CreateExperimentForm.js
@@ -23,7 +23,7 @@ export const CreateExperimentForm = ({ projectId, onCancel, onSuccess }) => {
     map,
     obj
   ) {
-    map[obj.name] = obj.type.toUpperCase();
+    map[obj.name] = obj.type;
     return map;
   },
     {});

--- a/ui/src/experiments/components/form/EditExperimentForm.js
+++ b/ui/src/experiments/components/form/EditExperimentForm.js
@@ -7,7 +7,6 @@ import { ConfigSectionTitle } from "components/config_section/ConfigSectionTitle
 import { useXpApi } from "hooks/useXpApi";
 import SegmenterContext from "providers/segmenters/context";
 import SettingsContext from "providers/settings/context";
-import { parseSegmenterValue } from "services/experiment/Segment";
 
 import { GeneralStep } from "./steps/GeneralStep";
 import { SegmentStep } from "./steps/SegmentStep";
@@ -21,14 +20,14 @@ export const EditExperimentForm = ({ projectId, onCancel, onSuccess }) => {
   const { segmenterConfig, getSegmenterOptions } = useContext(SegmenterContext);
 
   // retrieve name-type (in caps) mappings for active segmenters specified for this project
-  const segmenterTypes = getSegmenterOptions(segmenterConfig).reduce(function (
+  const segmenterTypes = getSegmenterOptions(segmenterConfig).reduce(function(
     map,
     obj
   ) {
     map[obj.name] = obj.type.toUpperCase();
     return map;
   },
-  {});
+    {});
 
   const requiredSegmenterNames = useMemo(
     () =>
@@ -53,11 +52,6 @@ export const EditExperimentForm = ({ projectId, onCancel, onSuccess }) => {
       if (!settings.segmenters.names.includes(key)) {
         delete experiment.segment[key];
       }
-      experiment.segment[key] = experiment.segment[key].map(
-        (segmenterValue) => {
-          return parseSegmenterValue(segmenterValue, segmenterTypes[key]);
-        }
-      );
     }
     return submitForm({ body: experiment.stringify() }).promise;
   };

--- a/ui/src/experiments/components/form/EditExperimentForm.js
+++ b/ui/src/experiments/components/form/EditExperimentForm.js
@@ -24,7 +24,7 @@ export const EditExperimentForm = ({ projectId, onCancel, onSuccess }) => {
     map,
     obj
   ) {
-    map[obj.name] = obj.type.toUpperCase();
+    map[obj.name] = obj.type;
     return map;
   },
     {});

--- a/ui/src/experiments/components/form/validation/schema.js
+++ b/ui/src/experiments/components/form/validation/schema.js
@@ -18,7 +18,7 @@ const experimentTierValues = experimentTiers.map((e) => e.value);
 // arrow format, for access to `this` from the invocation context:
 // https://stackoverflow.com/a/33308151
 
-const validateABTreatmentTraffic = function (items) {
+const validateABTreatmentTraffic = function(items) {
   const sum = items.reduce(
     (total, e) => total + (!!e.traffic ? e.traffic : 0),
     0
@@ -45,7 +45,7 @@ const validateABTreatmentTraffic = function (items) {
   return !!errors.length ? new yup.ValidationError(errors) : true;
 };
 
-const validateSwitchbackTreatmentTraffic = function (items) {
+const validateSwitchbackTreatmentTraffic = function(items) {
   const sum = items.reduce(
     (total, e) => total + (!!e.traffic ? e.traffic : 0),
     0
@@ -74,7 +74,7 @@ const validateSwitchbackTreatmentTraffic = function (items) {
   return !!errors.length ? new yup.ValidationError(errors) : true;
 };
 
-const validateTreatmentNames = function (items) {
+const validateTreatmentNames = function(items) {
   const uniqueNamesMap = items.reduce((acc, item) => {
     const current = item.name in acc ? acc[item.name] : 0;
     // If name is set, increment the count
@@ -143,10 +143,10 @@ const schema = [
     interval: yup.mixed().when("type", (type, schema) => {
       return type === "Switchback"
         ? yup
-            .number()
-            .required("Interval is required for Switchback experiments")
-            .integer("Interval must be an integer")
-            .min(5, "Interval cannot be lower than 5 minutes")
+          .number()
+          .required("Interval is required for Switchback experiments")
+          .integer("Interval must be an integer")
+          .min(5, "Interval cannot be lower than 5 minutes")
         : schema;
     }),
     tier: yup
@@ -190,7 +190,7 @@ const schema = [
                 }
               )
               .when("$segmenterTypes", (segmenterTypes) => {
-                switch (segmenterTypes[key]) {
+                switch (segmenterTypes[key].toUpperCase()) {
                   case "BOOL":
                     return yup.array(
                       yup
@@ -219,7 +219,7 @@ const schema = [
                         .typeError("Array elements must all be of type: STRING")
                     );
                   default:
-                    return false;
+                    return yup.array(); // Type is unknown for deactivated segmenters
                 }
               }),
           };

--- a/ui/src/services/experiment/Segment.js
+++ b/ui/src/services/experiment/Segment.js
@@ -1,10 +1,10 @@
 var jsonBig = require(`json-bigint`);
 
-export class Segment {}
+export class Segment { }
 
 export const parseSegmenterValue = (value, type) => {
   let parsedValue;
-  switch (type) {
+  switch (type.toUpperCase()) {
     case "BOOL":
       parsedValue = value.toLowerCase() === "true";
       break;

--- a/ui/src/services/segmenter/Segmenter.js
+++ b/ui/src/services/segmenter/Segmenter.js
@@ -20,7 +20,6 @@ export class Segmenter {
     const clone = cloneDeep(json);
     let obj = merge(new Segmenter(""), clone);
 
-    obj.type = obj.type.toLowerCase();
     obj.options =
       obj?.options != null && Object.keys(obj.options).length !== 0
         ? JSON.stringify(obj?.options)
@@ -74,7 +73,7 @@ export const newConstraint = (segmenter) => {
           : "[]",
       options:
         segmenter?.options != null &&
-        Object.keys(segmenter.options).length !== 0
+          Object.keys(segmenter.options).length !== 0
           ? JSON.stringify(segmenter?.options)
           : "",
     };

--- a/ui/src/settings/segmenters/components/form/components/SegmenterGeneralPanel.js
+++ b/ui/src/settings/segmenters/components/form/components/SegmenterGeneralPanel.js
@@ -124,7 +124,7 @@ export const SegmenterGeneralPanel = ({
             label={
               <FormLabelWithToolTip
                 label="Multi-Valued"
-                content="Specify if this segmenter can take on multiple values."
+                content="If selected, multiple values of the segmenter can be chosen at once, in segment configurations."
               />
             }
             checked={multiValued}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
This PR includes small UI fixes.
1. When the experiment data is posted from Create / Edit forms, a recent change (in https://github.com/gojek/turing-experiments/pull/16) was added to parse each segmenter value from string to the registered type. But this is unnecessary as the values in the options list are already of the correct type. The only occasion when it must be parsed from string is when it's keyed into a free-form text area, which happens if there are no pre-defined options for the segmenter (such as with S2ID) - that is handled [here](https://github.com/gojek/turing-experiments/blob/main/ui/src/experiments/components/form/components/segment_config/SegmenterConfigRow.js#L52). Hence, the parsing onSubmit experiment has now been removed in this PR.
![Screenshot 2022-07-15 at 12 08 19 PM](https://user-images.githubusercontent.com/23465343/179160730-94410b2b-ffba-4d85-b514-9fcadff02516.png)

2. Small change to "multi-valued" property tooltip for Custom Segmenter.

3. The segmenter type was previously returned in upper case. The PR https://github.com/gojek/turing-experiments/pull/16 also changes this to lower case. But this change hadn't been handled in the UI code fully. Now, removing all the toUpper / toLower conversions and applying the case change only during comparison.