### PR TITLE
[BUG] Fix experiment search filters when using real segmenter values

### DIFF
--- a/management-service/models/custom_segmenter.go
+++ b/management-service/models/custom_segmenter.go
@@ -550,7 +550,7 @@ func convertSegmenterValueToString(segmenterValue interface{}, typeName Segmente
 		if !ok {
 			return nil, fmt.Errorf("%s %s", errTmpl, schema.SegmenterTypeReal)
 		}
-		return fmt.Sprintf("%f", floatVal), nil
+		return strconv.FormatFloat(floatVal, 'f', -1, 64), nil
 	case SegmenterValueTypeBool:
 		boolVal, ok := segmenterValue.(bool)
 		if !ok {

--- a/management-service/models/custom_segmenter_test.go
+++ b/management-service/models/custom_segmenter_test.go
@@ -573,7 +573,7 @@ func TestConvertSegmenterValueToString(t *testing.T) {
 		"success | real": {
 			segmenterValue: 1.1,
 			typeName:       SegmenterValueTypeReal,
-			expected:       "1.100000",
+			expected:       "1.1",
 		},
 		"success | integer": {
 			segmenterValue: int64(1),

--- a/management-service/models/experiment_segment.go
+++ b/management-service/models/experiment_segment.go
@@ -134,7 +134,7 @@ func (s ExperimentSegmentRaw) ToStorageSchema(segmenterTypes map[string]schema.S
 				if !ok {
 					return nil, fmt.Errorf("%s %s", errTmpl, schema.SegmenterTypeReal)
 				}
-				strVals = append(strVals, fmt.Sprintf("%f", floatVal))
+				strVals = append(strVals, strconv.FormatFloat(floatVal, 'f', -1, 64))
 			}
 			segmenterVals[k] = strVals
 		case schema.SegmenterTypeBool:

--- a/management-service/services/segmenter_service.go
+++ b/management-service/services/segmenter_service.go
@@ -235,7 +235,7 @@ func (svc *segmenterService) ListSegmenters(
 		if err != nil {
 			return nil, err
 		}
-		for _, customSegmenter := range customSegmenters {
+		for idx, customSegmenter := range customSegmenters {
 			if err := customSegmenter.FromStorageSchema(segmenterTypes); err != nil {
 				return nil, err
 			}
@@ -249,10 +249,8 @@ func (svc *segmenterService) ListSegmenters(
 			}
 			// UpdatedAt and CreatedAt fields are manually updated for custom segmenters but not global segmenters since
 			// global segmenters do not contain these fields
-			customSegmenterUpdatedAt := customSegmenter.UpdatedAt
-			customSegmenterCreatedAt := customSegmenter.CreatedAt
-			formattedCustomSegmenter.UpdatedAt = &customSegmenterUpdatedAt
-			formattedCustomSegmenter.CreatedAt = &customSegmenterCreatedAt
+			formattedCustomSegmenter.UpdatedAt = &customSegmenters[idx].UpdatedAt
+			formattedCustomSegmenter.CreatedAt = &customSegmenters[idx].CreatedAt
 			if params.Status == nil || string(*params.Status) == string(*formattedCustomSegmenter.Status) {
 				allSegmenters = append(allSegmenters, formattedCustomSegmenter)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a bug fix that occurs when filtering experiments using segmenter values - when using segmenter values that are of the type real (`float` in go), experiments that have these values specified do not get filtered and displayed correctly in the `ListExperimentView`. 

E.g. Searching for experiments with the segmenter value corresponding to 1.4 (`o4`) for `custom_float` does not return the experiment named 'test':

<img width="1534" alt="Screenshot 2022-07-20 at 6 45 56 AM" src="https://user-images.githubusercontent.com/36802364/179898998-7743e0a0-d7fe-4097-a81c-d73283ddd5e3.png">
<img width="1539" alt="Screenshot 2022-07-20 at 6 42 20 AM" src="https://user-images.githubusercontent.com/36802364/179899014-b54485a6-ec49-49d5-9f5c-a2d417483832.png">
<img width="1608" alt="Screenshot 2022-07-20 at 6 43 27 AM" src="https://user-images.githubusercontent.com/36802364/179899020-9a408188-f2a5-4206-8f68-c04d94a5ee3f.png">

**Details**
The bug is caused by the backend storing float values as strings with trailing zeroes e.g. "1.40000", leading the gorm string condition search queries to fail when given search parameters without them i.e. "1.4". 

<img width="1284" alt="Screenshot 2022-07-20 at 6 12 22 AM" src="https://user-images.githubusercontent.com/36802364/179899530-ebb02de2-6856-4cf4-bd69-7ec230ec1f88.png">

The simple fix proposed in this PR thus enforces the strings generated from float values to have no trailing zeroes, by using the `strconv.FormatFloat` method detailed [here](https://pkg.go.dev/strconv#FormatFloat).

Although it is sufficient to apply this change to the storing of segmenter values used in experiments (i.e. in `management-service/models/experiment_segment.go`), a similar change has been made for the storing of segmenter values in custom segmenters for additional consistency.

**Extras**
This PR also includes a tiny code refactor from the comment made in https://github.com/gojek/turing-experiments/pull/19#discussion_r923221867.